### PR TITLE
Encode APP_SECRET to base64

### DIFF
--- a/signature-hmac-example.js
+++ b/signature-hmac-example.js
@@ -18,7 +18,8 @@ const payload = {
   }
 }
 
-const HMAC = getSignature(JSON.stringify(payload), APP_SECRET);
+const appSecretBuffer = new Buffer(APP_SECRET);
+const HMAC = getSignature(JSON.stringify(payload), appSecretBuffer.toString("base64"));
 const signature = { "HMAC": HMAC };
 const header = { "payloadVersion": 2, "signatureVersion" : 1 };
 


### PR DESCRIPTION
Python HMAC library requires appSecret string to be encoded into utf-8 or ASCII which results in wrong hmac and mismatch in signature.
So please encode appSecret to base64 before creating a new hmac.